### PR TITLE
Add May 2026 Awesome Interactions event and talks

### DIFF
--- a/.cursor/skills/add-person/SKILL.md
+++ b/.cursor/skills/add-person/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: add-person
+description: Creates or updates a person profile in src/content/persons/ from a name the user provides. Looks up existing entries, researches public profiles via web search, and fills Keystatic person fields. Use when the user wants to add, create, or populate a person, speaker, or profile.
+---
+
+# Add a Person Profile
+
+Creates or enriches a person `.yaml` file in `src/content/persons/`.
+
+Schema source: `src/app/keystatic/schema/collections/persons.ts`
+
+## Input
+
+The user provides a **display name** (e.g. `Alex Reardon`, `Sharkie`). Optional context helps disambiguation: employer, talk title, GitHub handle, “SydJS speaker”, etc.
+
+## Step 1 — Find or create the entry
+
+1. Derive the expected slug: lowercase, hyphenated full name (e.g. `Alex Reardon` → `alex-reardon`). Mononyms stay as one segment (`Sharkie` → `sharkie`).
+2. List `src/content/persons/*.yaml` and check:
+   - **Filename** matches `{slug}.yaml`
+   - **`name:`** field matches the user’s name (case-insensitive; allow minor spelling variants)
+3. **If a match exists**: open that file and **only fill empty/missing fields** unless the user explicitly asked to overwrite, or you find strong evidence that the person's details have changed.
+4. **If no match**: create `src/content/persons/{slug}.yaml`.
+
+## Step 2 — Research (web search)
+
+Search for the person using their name plus any context the user gave. Prefer primary sources: personal site, GitHub, conference bios, SydJS/meetup speaker pages, LinkedIn, Bluesky, X/Twitter, Mastodon.
+
+**Goal**: populate as many schema fields as possible with **verified** public information.
+
+### Field mapping (schema → YAML)
+
+| Schema field      | YAML key          | Format |
+| ----------------- | ----------------- | ------ |
+| `name`            | `name`            | Display name as the user gave it (title case unless they used a specific stylization) |
+| `avatar`          | `avatar`          | `/images/avatars/{slug}/avatar.{jpeg\|jpg\|png\|webp}` — see Avatar below |
+| `twitterHandle`   | `twitterHandle`   | Handle only, **no** `@` |
+| `bluesky`         | `bluesky`         | Handle only, **no** `@` (e.g. `user.bsky.social`) |
+| `github`          | `github`          | Username only |
+| `linkedin`        | `linkedin`        | Username or slug from profile URL, not full URL |
+| `mastodon`        | `mastodon`        | **Full** profile URL (e.g. `https://mastodon.social/@handle`) |
+| `website`         | `website`         | Full URL with scheme |
+| `socialLinks`     | `socialLinks`     | Only for other networks; each item needs `label` + `link` (full URL) |
+
+Omit YAML keys entirely when unknown — do not use empty strings for optional text fields.
+
+Use `socialLinks: []` when there are no extra links (matches existing files).
+
+### Avatar
+
+1. Set `avatar` to the conventional path: `/images/avatars/{slug}/avatar.{ext}`.
+2. If a reliable public avatar image URL is found, download it to `public/images/avatars/{slug}/avatar.{ext}` (create the directory). Use a sensible extension from the source - you can use CLI tools to determine the file type if needed.
+3. If no suitable image is found, alert the user to add the file under `public/images/avatars/{slug}/`.
+
+## Step 3 — Uncertainty rules
+
+**Wrong person is worse than an empty field.**
+
+- **Identity**: If search results could be multiple people with the same name, **stop** and ask the user to confirm (offer links or distinguishing details). Do not write the file until confirmed.
+- **Individual fields**: If a handle or URL is not clearly this person, **omit that field** and note what was skipped.
+- **Never invent** handles, URLs, or employers from guesswork.
+- After writing, give a short summary: fields filled, fields skipped, and anything the user should verify or supply (especially avatar file).
+
+## Step 4 — Write the file
+
+Match existing repo style (see `src/content/persons/alex-reardon.yaml`, `ben-buchanan.yaml`) and the defined schema above.
+
+**Updating**: preserve existing values; merge new research into gaps only.
+
+## Checklist
+
+```
+- [ ] Resolved name → slug; checked for existing file
+- [ ] Confirmed correct person (or asked user)
+- [ ] Web search done; fields verified or omitted
+- [ ] YAML written under src/content/persons/
+- [ ] Avatar path set; image downloaded if possible
+- [ ] User told what was filled, skipped, and needs manual follow-up
+```

--- a/src/content/events/2026-05-20-awesome-interactions-the-og-ai.mdoc
+++ b/src/content/events/2026-05-20-awesome-interactions-the-og-ai.mdoc
@@ -1,0 +1,24 @@
+---
+name: 'Awesome Interactions: the OG AI'
+date: 2026-05-20
+location: 'Atlassian Headquarters'
+address: Level 6, 341 George St · Sydney
+startTime: 06:00 PM
+endTime: 08:00 PM
+rsvpLink: https://www.meetup.com/en-au/sydjs-classic/events/308288162/
+featuredMedia:
+  discriminant: none
+talks:
+  - 2026-05-20-1-optimising-next-js-data-fetching
+  - 2026-05-20-2-web-speech-api
+---
+
+While Artificial Intelligence is making ground in your IDE, the User Interface and Interactions remains a space where a more human approach still holds fast.
+
+On the back of last month's artificial AI, this month we're returning to human AI — Awesome Interactions.
+
+Long time friend of SydJS, the always inspiring Alex Reardon returns with his latest insights into making the User Interface feel like more than 1s and 0s.
+
+He's joined by Leo Caseiro who's been investigating Text To Speech and how the Web embraces audio as well as the video that keeps us scrolling.
+
+Grab an RSVP. Spread the word. Join us next week 🤙🏽

--- a/src/content/events/2026-06-17.mdoc
+++ b/src/content/events/2026-06-17.mdoc
@@ -1,15 +1,16 @@
 ---
-name: SydJS advances into 2026
-date: 2026-05-20
-location: Atlassian Headquarters
+name: 'SydJS returns in 2026'
+date: 2026-06-17
+location: 'Atlassian Headquarters'
 address: Level 6, 341 George St · Sydney
 startTime: 06:00 PM
 endTime: 08:00 PM
-rsvpLink: https://www.meetup.com/en-au/sydjs-classic/events/308288162
+rsvpLink: https://www.meetup.com/en-au/sydjs-classic/events/312178072/
 featuredMedia:
   discriminant: none
 talks: []
 ---
+
 With the support of our great members — and equally great sponsors and hosts — the SydJS community has returned in 2025 and is celebrating its 16th year. And we wouldn't be the community we are, without you. But we know that we're not just the community of Developers, we're a community inside other communities.
 
 We're back, and we want to introduce you to great Developers, great Companies, and the ideas that help make both of them great.

--- a/src/content/persons/alex-reardon.yaml
+++ b/src/content/persons/alex-reardon.yaml
@@ -2,4 +2,6 @@ name: Alex Reardon
 avatar: /images/avatars/alex-reardon/avatar.jpeg
 twitterHandle: alexandereardon
 bluesky: alexreardon.bsky.social
+github: alexreardon
+website: https://alexreardon.dev/
 socialLinks: []

--- a/src/content/persons/leo-caseiro.yaml
+++ b/src/content/persons/leo-caseiro.yaml
@@ -1,4 +1,7 @@
 name: Leo Caseiro
 avatar: /images/avatars/leo-caseiro/avatar.jpeg
 twitterHandle: leocaseiro
+github: leocaseiro
+linkedin: leocaseiro
+website: https://leocaseiro.com/
 socialLinks: []

--- a/src/content/talks/2026-05-20-1-optimising-next-js-data-fetching.mdoc
+++ b/src/content/talks/2026-05-20-1-optimising-next-js-data-fetching.mdoc
@@ -1,0 +1,8 @@
+---
+name: Optimising Next.js data fetching
+featuredMedia:
+  discriminant: none
+speakers:
+  - alex-reardon
+---
+Alex Reardon digs into Next.js internals — how data fetching and reconciliation work with React Server Components, and how to structure an app so you fetch and resolve data efficiently without redundant round-trips or tangled client/server data flows.

--- a/src/content/talks/2026-05-20-2-web-speech-api.mdoc
+++ b/src/content/talks/2026-05-20-2-web-speech-api.mdoc
@@ -1,0 +1,8 @@
+---
+name: 'The Web Speech API: text-to-speech and speech-to-text'
+featuredMedia:
+  discriminant: none
+speakers:
+  - leo-caseiro
+---
+Leo Caseiro explores the browser's built-in speech APIs — how Text-to-Speech and Speech Recognition work on the web, and how he used them to build a "How to read" game for his kids.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Summary

- Add **Awesome Interactions: the OG AI** (2026-05-20) with Meetup copy and linked talks for Alex Reardon (Next.js data fetching) and Leo Caseiro (Web Speech API / "How to read" game).
- Move the generic placeholder event to **2026-06-17** (`SydJS returns in 2026`) with the correct June Meetup RSVP link.
- Enrich **Alex Reardon** and **Leo Caseiro** person profiles (GitHub, website, LinkedIn for Leo).
- Add **add-person** Cursor skill for scaffolding speaker profiles.
- Set `tsconfig.json` `jsx` to `react-jsx` (automatically done by Next.js)