### PR TITLE
Standardize LF line endings and fix Markdoc language detection

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+max_line_length = 80

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Treat Markdoc files as Markdown for GitHub language stats and diffs
+*.mdoc linguist-language=Markdown
+
+# Normalize all text files to LF on commit and checkout
+* text=auto eol=lf
+
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.webp  binary
+*.avif  binary
+*.gif   binary
+*.ico   binary
+*.woff  binary
+*.woff2 binary

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "semi": false
+  "semi": false,
+  "endOfLine": "lf"
 }


### PR DESCRIPTION
## Summary

- Add `.gitattributes` to treat `.mdoc` as Markdown on GitHub (fixes roff misclassification) and normalize text files to LF
- Add `.editorconfig` aligned with Prettier (2-space indent, 80-column soft wrap, LF)
- Set Prettier `endOfLine` to `lf` so format runs do not reintroduce CRLF on Windows

## Test plan

- [ ] Merge after Vercel check passes
- [ ] Confirm GitHub language stats show Markdown for `.mdoc` content after merge

Made with [Cursor](https://cursor.com)