### PR TITLE
Add June and July 2026 events

### DIFF
--- a/src/content/events/2026-06-17.mdoc
+++ b/src/content/events/2026-06-17.mdoc
@@ -1,20 +1,22 @@
 ---
-name: 'SydJS returns in 2026'
+name: 'SydJS: AI — Adding Insight'
 date: 2026-06-17
 location: 'Atlassian Headquarters'
-address: Level 6, 341 George St · Sydney
+address: Level 29, 363 George St · Sydney
 startTime: 06:00 PM
 endTime: 08:00 PM
 rsvpLink: https://www.meetup.com/en-au/sydjs-classic/events/312178072/
 featuredMedia:
   discriminant: none
-talks: []
+talks:
+  - 2026-06-17-1-ai-adding-insight
 ---
+What’s even better than uncovering insights into a rising technology? Getting to stand on the shoulders of giants to look ahead.
 
-With the support of our great members — and equally great sponsors and hosts — the SydJS community has returned in 2025 and is celebrating its 16th year. And we wouldn't be the community we are, without you. But we know that we're not just the community of Developers, we're a community inside other communities.
+What’s even better than that chance? Having the same team return to reprise what you’d learnt.
 
-We're back, and we want to introduce you to great Developers, great Companies, and the ideas that help make both of them great.
+What’s even better than that revision? Revising just that little bit slower and going just that little bit deeper.
 
-If this sounds like something you want to be a part of, that's GREAT. Keep your eye on your inbox and we'll work to keep SydJS growing.
+That’s right, Thinkmill’s Dinesh Pandiyan is back this month to guide you through how AI can be unlocked to add value to your company, your team, and your workflow.
 
-Stay safe. Stay clean. Stay kind.
+One not to miss!

--- a/src/content/events/2026-07-22.mdoc
+++ b/src/content/events/2026-07-22.mdoc
@@ -1,0 +1,20 @@
+---
+name: 'SydJS returns in 2026'
+date: 2026-07-22
+location: Atlassian Headquarters
+address: Level 29, 363 George St · Sydney
+startTime: 06:00 PM
+endTime: 08:00 PM
+rsvpLink: https://www.meetup.com/en-au/sydjs-classic/events/312469937/
+featuredMedia:
+  discriminant: none
+talks: []
+---
+
+With the support of our great members — and equally great sponsors and hosts — the SydJS community has returned in 2025 and is celebrating its 16th year. And we wouldn't be the community we are, without you. But we know that we're not just the community of Developers, we're a community inside other communities.
+
+We're back, and we want to introduce you to great Developers, great Companies, and the ideas that help make both of them great.
+
+If this sounds like something you want to be a part of, that's GREAT. Keep your eye on your inbox and we'll work to keep SydJS growing.
+
+Stay safe. Stay clean. Stay kind.

--- a/src/content/talks/2026-06-17-1-ai-adding-insight.mdoc
+++ b/src/content/talks/2026-06-17-1-ai-adding-insight.mdoc
@@ -1,0 +1,8 @@
+---
+name: 'AI — Adding Insight'
+featuredMedia:
+  discriminant: none
+speakers:
+  - dinesh-pandiyan
+---
+Dinesh Pandiyan from Thinkmill returns to guide you through how AI can be unlocked to add value to your company, your team, and your workflow.


### PR DESCRIPTION
## Summary
- Update the June 2026 event to Level 29, 363 George St with the AI Adding Insight description and a talk for Dinesh Pandiyan
- Add a July 2026 placeholder event (`2026-07-22.mdoc`) with the generic SydJS returns copy

## Test plan
- [ ] Verify `/events/2026-06-17` shows the updated venue, description, and Dinesh talk
- [ ] Verify `/events/2026-07-22` shows the placeholder July event