### PR TITLE
Add Joshua Crowley talk to July 2026 event

### DIFF
--- a/src/content/events/2026-07-22.mdoc
+++ b/src/content/events/2026-07-22.mdoc
@@ -18,6 +18,6 @@ Or have you tried AI and want to hone your approach? Or help other developers le
 
 This month, the team behind Cursor Sydney will take over SydJS and give you another way to consider AI.
 
-Joshua Crowley, a long-time friend of SydJS, Cursor Regional Ambassador, and Design Engineer at Envato, will show us a day in the life of a design engineer using Cursor.
+Josh Crowley, a long-time friend of SydJS and a Cursor Regional Ambassador, will show us how he uses AI to collect, combine, and collaborate on ideas.
 
-Drawing on a recent workshop he delivered for designers, Joshua will share practical tips and tricks for bringing Cursor into design workflows.
+Using real examples, he'll show how AI can make things faster, but also allow you to slow down and get the outcome you need.

--- a/src/content/events/2026-07-22.mdoc
+++ b/src/content/events/2026-07-22.mdoc
@@ -8,7 +8,8 @@ endTime: 08:00 PM
 rsvpLink: https://www.meetup.com/en-au/sydjs-classic/events/312469937/
 featuredMedia:
   discriminant: none
-talks: []
+talks:
+  - 2026-07-22-1-using-cursor-as-a-design-engineer
 ---
 
 Are you holding back on exploring AI because you've heard it's going to change the way we work with the web? Have you seen vibe coders and don't quite get the attraction?
@@ -17,6 +18,6 @@ Or have you tried AI and want to hone your approach? Or help other developers le
 
 This month, the team behind Cursor Sydney will take over SydJS and give you another way to consider AI.
 
-Josh Crowley, a long-time friend of SydJS and a Cursor Regional Ambassador, will show us how he uses AI to collect, combine, and collaborate on ideas.
+Joshua Crowley, a long-time friend of SydJS, Cursor Regional Ambassador, and Design Engineer at Envato, will show us a day in the life of a design engineer using Cursor.
 
-Using real examples, he'll show how AI can make things faster, but also allow you to slow down and get the outcome you need.
+Drawing on a recent workshop he delivered for designers, Joshua will share practical tips and tricks for bringing Cursor into design workflows.

--- a/src/content/talks/2026-07-22-1-using-cursor-as-a-design-engineer.mdoc
+++ b/src/content/talks/2026-07-22-1-using-cursor-as-a-design-engineer.mdoc
@@ -1,0 +1,10 @@
+---
+name: Using Cursor as a Design Engineer
+featuredMedia:
+  discriminant: none
+speakers:
+  - joshua-crowley
+---
+Joshua Crowley shows us a day in the life of a Design Engineer at Envato and recaps a recent workshop he delivered teaching designers how to use Cursor.
+
+Along the way, Joshua will share practical tips and tricks for bringing Cursor into design workflows.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new talk entry for Joshua Crowley: `Using Cursor as a Design Engineer`
- link the new talk from the July 22, 2026 event
- keep the existing July event page copy unchanged

## Verification
- confirmed the event content points at the new talk entry
- `pnpm build` is currently blocked by missing required Keystatic GitHub environment variables in this cloud environment (`KEYSTATIC_GITHUB_CLIENT_ID`, `KEYSTATIC_GITHUB_CLIENT_SECRET`, `KEYSTATIC_SECRET`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5208cf55-40f8-4a8b-8be4-e5a218935416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5208cf55-40f8-4a8b-8be4-e5a218935416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

